### PR TITLE
feat: add support for isolation scope setting (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ map(object({
 
 Default: `{}`
 
+### <a name="input_isolation_scope"></a> [isolation\_scope](#input\_isolation\_scope)
+
+Description: (Optional) The isolation scope for the user assigned identity. The only possible value is Regional.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
 Description:   Controls the Resource Lock configuration for this resource. The following properties can be specified:
@@ -126,7 +134,7 @@ Default: `null`
 
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
-Description: A map of role assignments to create on the container app environment. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+Description: A map of role assignments to create for the user assigned identity. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
 - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
 - `scope` - The ID of the scope to assign the role to.

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ resource "azurerm_user_assigned_identity" "this" {
   location            = var.location
   name                = var.name
   resource_group_name = var.resource_group_name
+  isolation_scope     = var.isolation_scope
   tags                = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,17 @@ variable "federated_identity_credentials" {
   nullable    = false
 }
 
+variable "isolation_scope" {
+  type        = string
+  default     = null
+  description = "(Optional) The isolation scope for the user assigned identity. The only possible value is Regional."
+
+  validation {
+    condition     = var.isolation_scope == null ? true : var.isolation_scope == "Regional"
+    error_message = "The isolation_scope must be null or `Regional`."
+  }
+}
+
 variable "lock" {
   type = object({
     kind = string
@@ -82,7 +93,7 @@ variable "role_assignments" {
   }))
   default     = {}
   description = <<-EOT
-  A map of role assignments to create on the container app environment. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  A map of role assignments to create for the user assigned identity. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
   - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
   - `scope` - The ID of the scope to assign the role to.


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

This PR adds support for the optional `isolation_scope` available on the `azurerm_user_assigned_identity` resource.

I also update the documentation replacing faulty "container app environment" reference.

Closes #131 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
